### PR TITLE
Remove unnecessary feature annotations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,6 @@
 //! }
 //! ```
 
-#![feature(const_if_match)]
-#![feature(const_loop)]
-
 /// A const evaluated sha1 function.
 ///
 /// # Use


### PR DESCRIPTION
`#![feature]` doesn't work on stable and beta even when the feature is already stabilized preventing this module from automatically working on those in the future. Meanwhile, it's no longer necessary to use those annotations on nightly.