### PR TITLE
Removed limit on input data size

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub const fn sha1(data: &[u8]) -> Digest {
 ///
 /// ```
 /// const fn signature() -> const_sha1::Digest {
-///     const_sha1::sha1(stringify!(MyType).as_bytes())
+///     const_sha1::sha1_of_buffer(&const_sha1::ConstBuffer::from_slice(stringify!(MyType).as_bytes()))
 /// }
 /// ```
 pub const fn sha1_of_buffer(data: &ConstBuffer) -> Digest {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,7 +528,7 @@ mod tests {
             assert_eq!(hash, expected);
         }
 
-        for &(s, expected) in tests.iter().filter(|(s,_)| s.len() <= BUFFER_SIZE) {
+        for &(s, expected) in tests.iter().filter(|(s, _)| s.len() <= BUFFER_SIZE) {
             let hash = sha1_of_buffer(&ConstBuffer::from_slice(s.as_bytes())).to_string();
 
             assert_eq!(hash, expected);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,8 @@ const fn process_blocks(
         let mut i = 0;
         while i != 16 {
             let off = offset + (i * 4);
-            result[i] 
-                = ((input[off + 3] as u32))
+            result[i] = 0
+                | ((input[off + 3] as u32) << 0)
                 | ((input[off + 2] as u32) << 8)
                 | ((input[off + 1] as u32) << 16)
                 | ((input[off + 0] as u32) << 24);


### PR DESCRIPTION
Perhaps the buffer was inherited from C++/WinRT, but haven't seen it for a long time where compile time generation of interface identifiers was heavily used. Anyway, it doesn't matter.

The change removes `ConstBuffer` and its limit put on an input. The price is a different `sha1` signature, it accepts a slice now.