### PR TITLE
Renamed slice returning method of digest

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -426,7 +426,7 @@ pub struct Digest {
 
 impl Digest {
     /// Returns the 160 bit (20 byte) digest as a byte array.
-    pub const fn bytes(&self) -> [u8; 20] {
+    pub const fn as_bytes(&self) -> [u8; 20] {
         [
             (self.data[0] >> 24) as u8,
             (self.data[0] >> 16) as u8,


### PR DESCRIPTION
It's a minor and very cosmetic change, so am fine if it gets declined. Anyway, I decided to make it for unification with other same methods in the standard library.